### PR TITLE
Prepend "http://" in url if not present already.

### DIFF
--- a/KS/KSMod.cs
+++ b/KS/KSMod.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using log4net;
 using Newtonsoft.Json.Linq;
 
@@ -106,6 +107,13 @@ namespace CKAN.NetKAN
 
             escaped = escaped.Replace("[",Uri.HexEscape('['));
             escaped = escaped.Replace("]",Uri.HexEscape(']'));
+
+			// Make sure we have a "http://" or "https://" start.
+			if (!Regex.IsMatch(escaped, "(?i)^(http|https)://"))
+			{
+				// Prepend "http://", as we do not know if the site supports https.
+				escaped = "http://" + escaped;
+			}
 
             return escaped;
         }


### PR DESCRIPTION
At least one KerbalStuff mod (UniversalStorage) does not put http:// or https:// in the homepage field. This checks for either of those terms and inserts http:// if necessary.

I do not know of a method to check if the remote server supports https connections. Else, it would be optimal to perform the check here and insert the right version.

Closes https://github.com/KSP-CKAN/CKAN-support/issues/62.