### PR TITLE
Moar hoop jumping for KS escaping.

### DIFF
--- a/CKAN-netkan.sln
+++ b/CKAN-netkan.sln
@@ -1,6 +1,6 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
+# Visual Studio 2012
 VisualStudioVersion = 12.0.21005.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CKAN-netkan", "CKAN-netkan.csproj", "{4336F356-33DB-442A-BF74-5E89AF47A5B9}"
@@ -16,6 +16,41 @@ Global
 		{4336F356-33DB-442A-BF74-5E89AF47A5B9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{92442BD6-F533-4BB8-8E04-9D93A038035E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{92442BD6-F533-4BB8-8E04-9D93A038035E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+	EndGlobalSection
+	GlobalSection(MonoDevelopProperties) = preSolution
+		Policies = $0
+		$0.TextStylePolicy = $1
+		$1.inheritsSet = VisualStudio
+		$1.inheritsScope = text/plain
+		$1.scope = text/x-csharp
+		$0.CSharpFormattingPolicy = $2
+		$2.IndentSwitchBody = True
+		$2.IndentBlocksInsideExpressions = True
+		$2.AnonymousMethodBraceStyle = NextLine
+		$2.PropertyBraceStyle = NextLine
+		$2.PropertyGetBraceStyle = NextLine
+		$2.PropertySetBraceStyle = NextLine
+		$2.EventBraceStyle = NextLine
+		$2.EventAddBraceStyle = NextLine
+		$2.EventRemoveBraceStyle = NextLine
+		$2.StatementBraceStyle = NextLine
+		$2.ElseNewLinePlacement = NewLine
+		$2.CatchNewLinePlacement = NewLine
+		$2.FinallyNewLinePlacement = NewLine
+		$2.WhileNewLinePlacement = DoNotCare
+		$2.ArrayInitializerWrapping = DoNotChange
+		$2.ArrayInitializerBraceStyle = NextLine
+		$2.BeforeMethodDeclarationParentheses = False
+		$2.BeforeMethodCallParentheses = False
+		$2.BeforeConstructorDeclarationParentheses = False
+		$2.NewLineBeforeConstructorInitializerColon = NewLine
+		$2.NewLineAfterConstructorInitializerColon = SameLine
+		$2.BeforeDelegateDeclarationParentheses = False
+		$2.NewParentheses = False
+		$2.SpacesBeforeBrackets = False
+		$2.inheritsSet = Mono
+		$2.inheritsScope = text/x-csharp
+		$2.scope = text/x-csharp
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/KS/KSAPI.cs
+++ b/KS/KSAPI.cs
@@ -57,11 +57,21 @@ namespace CKAN.NetKAN
         /// <summary>
         ///     Returns the route with the KerbalStuff URI (not the API URI) pre-pended.
         /// </summary>
-        /// <returns>The path.</returns>
-        /// <param name="route">Route.</param>
         public static Uri ExpandPath(string route)
         {
-            return new Uri(kerbalstuff, route);
+            log.DebugFormat("Expanding {0} to full KS URL", route);
+
+            // Alas, this isn't as simple as it may sound. For some reason
+            // some—but not all—KS mods don't work the same way if the path provided
+            // is escaped or un-escaped. Since our curl implementation preserves the
+            // "original" string used to download a mod, we need to jump through some
+            // hoops to make sure this is escaped.
+
+            var url = new Uri (kerbalstuff,route);
+            var url_fixed = new Uri (Uri.EscapeUriString(url.ToString()));
+
+            log.DebugFormat ("Expanded URL is {0}", url_fixed.OriginalString);
+            return url_fixed;
         }
     }
 }


### PR DESCRIPTION
I don't know why, but KS *sometimes* acts differently if spaces are
escaped in URLs, and sometimes it doesn't. This horrible kludge means
they always end up being escaped, which means I can merge my OTHER
PRs that fix bad data that ended up in the NetKAN repo, which means
I can then turn our full range of tests back on for NetKAN PRs, get
rid of spec-breaking identifiers, release a new CKAN client, and then
maybe play KSP which is all I've wanted to really do today. #toomanyyaks