### PR TITLE
Handle our own escaping for KS URL expansion

### DIFF
--- a/KS/KSAPI.cs
+++ b/KS/KSAPI.cs
@@ -67,9 +67,21 @@ namespace CKAN.NetKAN
             // "original" string used to download a mod, we need to jump through some
             // hoops to make sure this is escaped.
 
-            var url = new Uri (kerbalstuff,route);
-            var url_fixed = new Uri (Uri.EscapeUriString(url.ToString()));
+            // Update: The Uri class under mono doesn't un-escape everything when
+            // .ToString() is called, even though the .NET documentation says that it
+            // should. Rather than using it and going through escaping hell, we'll simply
+            // concat our strings together and preserve escaping that way. If KS ever
+            // start returning fully qualified URLs then we should see everyting break
+            // pretty quickly, and we can rejoice because we won't need any of this code
+            // again. -- PJF, KSP-CKAN/CKAN#816.
 
+            // Step 1: Escape any spaces present. KS seems to escape everything else fine.
+            route = Regex.Replace(route," ","%20");
+
+            // Step 2: Trim leading slashes and prepend the KS host
+            Uri url_fixed = new Uri(kerbalstuff + route.TrimStart('/'));
+
+            // Step 3: Profit!
             log.DebugFormat ("Expanded URL is {0}", url_fixed.OriginalString);
             return url_fixed;
         }

--- a/Tests/NetKAN/KSMod.cs
+++ b/Tests/NetKAN/KSMod.cs
@@ -71,15 +71,15 @@ namespace NetKAN.KerbalStuffTests
         }
 
         [Test]
+        [TestCase("/mod/42/Example/download/1.23", Result="https://kerbalstuff.com/mod/42/Example/download/1.23")]
+        [TestCase("/mod/42/Example%20With%20Spaces/download/1.23", Result="https://kerbalstuff.com/mod/42/Example%20With%20Spaces/download/1.23")]
+        [TestCase("/mod/42/Example With Spaces/download/1.23", Result="https://kerbalstuff.com/mod/42/Example%20With%20Spaces/download/1.23")]
+        [TestCase("/mod/79/Salyut%20Stations%20%26%20Soyuz%20Ferries/download/0.93",Result="https://kerbalstuff.com/mod/79/Salyut%20Stations%20%26%20Soyuz%20Ferries/download/0.93")]
         // GH #816: Ensure URLs with & are encoded correctly.
-        public void KS_URL_encode_816()
+        public string KS_URL_encode_816(string path)
         {
-            Assert.AreEqual(
-                CKAN.NetKAN.KSAPI.ExpandPath("/mod/79/Salyut%20Stations%20%26%20Soyuz%20Ferries/download/0.93").OriginalString,
-                "https://kerbalstuff.com/mod/79/Salyut%20Stations%20%26%20Soyuz%20Ferries/download/0.93"
-            );
+            return CKAN.NetKAN.KSAPI.ExpandPath(path).OriginalString;
         }
-
 
         public CKAN.NetKAN.KSMod test_ksmod()
         {

--- a/Tests/NetKAN/KSMod.cs
+++ b/Tests/NetKAN/KSMod.cs
@@ -70,6 +70,17 @@ namespace NetKAN.KerbalStuffTests
             Assert.AreEqual(711, mod.Latest().id, "GH #214 - Select default_version_id");
         }
 
+        [Test]
+        // GH #816: Ensure URLs with & are encoded correctly.
+        public void KS_URL_encode_816()
+        {
+            Assert.AreEqual(
+                CKAN.NetKAN.KSAPI.ExpandPath("/mod/79/Salyut%20Stations%20%26%20Soyuz%20Ferries/download/0.93").OriginalString,
+                "https://kerbalstuff.com/mod/79/Salyut%20Stations%20%26%20Soyuz%20Ferries/download/0.93"
+            );
+        }
+
+
         public CKAN.NetKAN.KSMod test_ksmod()
         {
             var ksmod = new CKAN.NetKAN.KSMod


### PR DESCRIPTION
* Some (but not all) KS mods can only be downloaded if their URLs are fully escaped.
* Thus, we always escape URLs to KS mods
* Some KS mods include ampersands in their URLs
* Mono fails when unescaping and then escaping URLs containing amperands.
* Thus, we have our own code to expand KS URLs.
* Includes tests
* For and closes KSP-CKAN/CKAN#816.