### PR TITLE
Setting `x_netkan_force_v` will force a 'v' onto versions.

### DIFF
--- a/MainClass.cs
+++ b/MainClass.cs
@@ -186,11 +186,14 @@ namespace CKAN.NetKAN
                     }
                 }
 
-                metadata = FixVersionStrings(metadata);
-
-                // If we've got this far, we need to re-inflate our mod, too.
-                mod = CkanModule.FromJson (metadata.ToString ());
             }
+
+            // Fix our version string, if required.
+            metadata = FixVersionStrings(metadata);
+
+            // Re-inflate our mod, in case our vref or FixVersionString routines have
+            // altered it at all.
+            mod = CkanModule.FromJson (metadata.ToString ());
 
             // All done! Write it out!
 
@@ -560,6 +563,7 @@ namespace CKAN.NetKAN
         /// </summary>
         internal static JObject FixVersionStrings(JObject metadata)
         {
+            log.Debug("Fixing version strings (if required)...");
 
             JToken force_v;
             if (metadata.TryGetValue("x_netkan_force_v", out force_v) && (bool) force_v)

--- a/MainClass.cs
+++ b/MainClass.cs
@@ -186,7 +186,9 @@ namespace CKAN.NetKAN
                     }
                 }
 
-                // If we've done this, we need to re-inflate our mod, too.
+                metadata = FixVersionStrings(metadata);
+
+                // If we've got this far, we need to re-inflate our mod, too.
                 mod = CkanModule.FromJson (metadata.ToString ());
             }
 
@@ -550,6 +552,36 @@ namespace CKAN.NetKAN
 
             return new NetFileCache(tempdir);
         }
+
+        /// <summary>
+        /// Fixes version strings. Currently this adds a 'v' if
+        /// 'x_netkan_force_v' is set, and the version string does not
+        /// already begin with a 'v'.
+        /// </summary>
+        internal static JObject FixVersionStrings(JObject metadata)
+        {
+
+            JToken force_v;
+            if (metadata.TryGetValue("x_netkan_force_v", out force_v) && (bool) force_v)
+            {
+                // Force a 'v' in front of the version string if it's not there
+                // already.
+
+                string version = (string) metadata.GetValue("version");
+
+                if (!version.StartsWith("v"))
+                {
+                    log.DebugFormat("Force-adding 'v' to start of {0}", version);
+                    version = "v" + version;
+                    metadata["version"] = version;
+                }
+            }
+
+            return metadata;
+
+        }
+
+
     }
 
     internal class NetKanRemote

--- a/Tests/NetKAN/MainClass.cs
+++ b/Tests/NetKAN/MainClass.cs
@@ -1,0 +1,43 @@
+﻿using CKAN.NetKAN;
+using NUnit.Framework;
+using Newtonsoft.Json.Linq;
+
+namespace NetKAN
+{
+    [TestFixture]
+    public class MainClassTests
+    {
+
+        [Test]
+        public void FixVersionStringsUnharmed()
+        {
+            JObject metadata = JObject.Parse(Tests.TestData.DogeCoinFlag_101());
+
+            Assert.AreEqual("1.01", (string) metadata["version"], "Original version as expected");
+
+            metadata = MainClass.FixVersionStrings(metadata);
+            Assert.AreEqual("1.01", (string) metadata["version"], "Version unharmed without x_netkan_force_v");
+        }
+
+        [Test]
+        // Test with and without x_netkan_force_v, and with and without a 'v' prepended already.
+        [TestCase(@"{""version"" : ""1.01""}", "1.01", "1.01")]
+        [TestCase(@"{""version"" : ""1.01"", ""x_netkan_force_v"" : ""true""}", "1.01", "v1.01")]
+        [TestCase(@"{""version"" : ""1.01"", ""x_netkan_force_v"" : ""false""}", "1.01", "1.01")]
+        [TestCase(@"{""version"" : ""v1.01""}", "v1.01", "v1.01")]
+        [TestCase(@"{""version"" : ""v1.01"", ""x_netkan_force_v"" : ""true""}", "v1.01", "v1.01")]
+        [TestCase(@"{""version"" : ""v1.01"", ""x_netkan_force_v"" : ""false""}", "v1.01", "v1.01")]
+        public void FixVersionStrings(string json, string orig_version, string new_version)
+        {
+            JObject metadata = JObject.Parse(json);
+
+            Assert.AreEqual(orig_version, (string) metadata["version"], "JSON parsed as expected");
+
+            metadata = MainClass.FixVersionStrings(metadata);
+
+            Assert.AreEqual(new_version, (string) metadata["version"], "Output string as expected");
+        }
+
+    }
+}
+

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -52,6 +52,7 @@
     <Compile Include="ZipLib.cs" />
     <Compile Include="NetKAN\AVC.cs" />
     <Compile Include="DisposableKSP.cs" />
+    <Compile Include="NetKAN\MainClass.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>


### PR DESCRIPTION
`netkan.exe` maintains version strings exactly as we see them in the release
information. However mod authors sometimes switch between adding a 'v' onto the
front of their releases, and sometimes leaving it off.

This change introduces a `x_netkan_force_v` field. If present and set to
'true', this will prepend a 'v' to the version string of any indexed mod if a
'v' is not already present.

This should solve our recent pain with InfernalRobotics,
RasterPropMonitor-Core, and countless other mods.

This requires no changes to end-user clients, and no changes to specs (although
I'll send in a separate PR that documents it as part of the netkan
pseudo-spec). Users of any CKAN version can enjoy us enforcing version string
consistency.

Comes with test cases. Also tested by adding a `x_netkan_force_v` to my local `InfernalRobotics.netkan` and rejoicing at the result.