### PR TITLE
Better error message from KS in case of 404.

### DIFF
--- a/KS/KSAPI.cs
+++ b/KS/KSAPI.cs
@@ -7,6 +7,15 @@ using CurlSharp;
 
 namespace CKAN.NetKAN
 {
+    /// <summary>
+    /// Internal class to read errors from KS.
+    /// </summary>
+    internal class KSError
+    {
+        public string reason;
+        public bool error;
+    }
+
     // KerbalStuff API
     public class KSAPI
     {
@@ -43,6 +52,16 @@ namespace CKAN.NetKAN
         public static KSMod Mod(int mod_id)
         {
             string json = Call("/mod/" + mod_id);
+
+            // Check if the mod has been removed from KS.
+            KSError error = JsonConvert.DeserializeObject<KSError>(json);
+
+            if (error.error)
+            {
+                string error_message = String.Format("Could not get the mod from KS, reason: {0}.", error.reason);
+                throw new Kraken(error_message);
+            }
+
             return Mod(json);
         }
 


### PR DESCRIPTION
If a mod is removed from KS, the error from netkan-bot is currently:
```
Unhandled Exception:
System.ArgumentNullException: Argument cannot be null.
```
This catches that case and print the reason. May work in other error cases as well from KS, but not tested.