### PR TITLE
GitHubAPI uses KSAPI logger

### DIFF
--- a/Github/GithubAPI.cs
+++ b/Github/GithubAPI.cs
@@ -14,7 +14,7 @@ namespace CKAN.NetKAN
     {
         private static readonly string asset_match = "/asset_match/";
         private static readonly Uri api_base = new Uri("https://api.github.com/");
-        private static readonly ILog log = LogManager.GetLogger(typeof (KSAPI));
+        private static readonly ILog log = LogManager.GetLogger(typeof(GithubAPI));
         private static readonly WebClient web = new WebClient();
         private static bool done_init;
 


### PR DESCRIPTION
While debugging a failing build, I had trouble finding the code which generated the output I read in the netkan-bot log. Turns out GitHubAPI for some reason was using the KSAPI logger.