### PR TITLE
Add in new custom field for kerbalstuff mods.

### DIFF
--- a/KS/KSMod.cs
+++ b/KS/KSMod.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 using log4net;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 namespace CKAN.NetKAN
@@ -20,6 +21,8 @@ namespace CKAN.NetKAN
         public KSVersion[] versions;
         public Uri website;
         public int default_version_id;
+        [JsonConverter(typeof(KSVersion.JsonConvertFromRelativeKsUri))]
+        public Uri background;
 
         public override string ToString()
         {
@@ -71,6 +74,7 @@ namespace CKAN.NetKAN
 
             Inflate(metadata, "download", version.download_path.OriginalString);
             Inflate(metadata, "x_generated_by", "netkan");
+            if(background!=null) Inflate(metadata, "x_screenshot", Escape(background));
             Inflate(metadata, "download_size", download_size);
 
             if (website != null)

--- a/KS/KSVersion.cs
+++ b/KS/KSVersion.cs
@@ -32,13 +32,16 @@ namespace CKAN.NetKAN
         /// <summary>
         /// A simple helper class to prepend KerbalStuff URLs.
         /// </summary>
-        private class JsonConvertFromRelativeKsUri : JsonConverter
+        internal class JsonConvertFromRelativeKsUri : JsonConverter
         {
             public override object ReadJson(
                 JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer
             )
             {
-                return KSAPI.ExpandPath(reader.Value.ToString());
+                if(reader.Value!=null)
+                    return KSAPI.ExpandPath(reader.Value.ToString());
+                return null;
+
             }
 
             public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)


### PR DESCRIPTION
"x_screenshot" contains a url to the screenshot used as a icon on kerbalstuff.
A user on IRC requested the field and given that a number of KS mods it seemed a simple request.
